### PR TITLE
Correct textile.photos markdown link syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,4 +65,4 @@ The [https://fb.textile.photos/](https://fb.textile.photos/) app runs entirely i
 
 ## What about Instagram?
 
-Not yet. But we plan to include export helpers for all the main social sites in our [https://textile.photos/](textile.photos app), sign up and we'll get you an invite asap. 
+Not yet. But we plan to include export helpers for all the main social sites in our [textile.photos app](https://www.textile.photos/), sign up and we'll get you an invite asap. 


### PR DESCRIPTION
It looks like someone had put the text and link the wrong way around, I switched the two around and the link now displays properly and will take you off to the textile.photos website rather than a dead page.

Nice project :)